### PR TITLE
Extend limbda with basic range functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,10 @@
     "prefer-arrow-callback": 0,
     "comma-dangle": ["error", "always-multiline"],
     "no-bitwise": 0,
-    "no-return-assign": 0
+    "no-return-assign": 1,
+    "no-cond-assign": 1,
+    "one-var": 1,
+    "one-var-declaration-per-line": 1,
+    "no-multi-assign": 1
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,8 @@
     "no-underscore-dangle": 0,
     "prefer-rest-params": 0,
     "prefer-arrow-callback": 0,
-    "comma-dangle": ["error", "always-multiline"]
+    "comma-dangle": ["error", "always-multiline"],
+    "no-bitwise": 0,
+    "no-return-assign": 0
   }
 }

--- a/benchmark/benchmarks.js
+++ b/benchmark/benchmarks.js
@@ -19,6 +19,8 @@ for (let n of range(0, 10000)) {
   numbersToSum.push(n);
 }
 
+// TODO: add jQuery & Rambda
+
 reduceSuite
   .add(
     'limbda#reduce | Sum numbers',

--- a/lib/irange.js
+++ b/lib/irange.js
@@ -1,0 +1,7 @@
+
+export default function *irange(until) {
+  // NOTE: index or infinite range generator,
+  // generates a monotonically increasing
+  // range upto until value non-inclusive
+  // or to max safe int val, from zero.
+}

--- a/lib/limbda.js
+++ b/lib/limbda.js
@@ -2,3 +2,4 @@ export { default as isIterable } from './isIterable';
 export { default as reduce } from './reduce';
 export { default as map } from './map';
 export { default as filter } from './filter';
+export { default as range } from './range';

--- a/lib/range.js
+++ b/lib/range.js
@@ -1,38 +1,37 @@
+import reduce from './reduce';
 
 export default function *range(start, end, step = 1, inclusive = true) {
-  const args = [
-    start = +start,
-    end = +end,
-    step = +step,
-  ];
+  const args = [+start, +end, +step];
+  const argIsNaN = reduce(
+    (acc, val) => acc |= Number.isNaN(val), // eslint-disable-line no-param-reassign
+    args,
+    false,
+  );
+  if (argIsNaN) throw new Error('Start, end, step arguments cannot be NaN.');
 
-  const argIsNaN = args
-    .reduce((acc, val) => (acc |= Number.isNaN(val)), false);
-  if (argIsNaN) throw new Error('All arguments must be Number type.');
+  // const argsAreIntegers = args
+  //   .reduce((acc, val) => (acc &= Number.isInteger(val)), true);
 
-  const argsAreIntegers = args
-    .reduce((acc, val) => (acc &= Number.isInteger(val)), true);
+  // const maxCeil = argsAreIntegers ? Number.MAX_SAFE_INTEGER : Number.MAX_VALUE;
+  // const minFloor = argsAreIntegers ? Number.MIN_SAFE_INTEGER : Number.MIN_VALUE;
+  // const isIncreasing = (start + step) > start;
 
-  const maxCeil = argsAreIntegers ? Number.MAX_SAFE_INTEGER : Number.MAX_VALUE;
-  const minFloor = argsAreIntegers ? Number.MIN_SAFE_INTEGER : Number.MIN_VALUE;
-  const isIncreasing = (start + step) > start;
+  // if (isIncreasing && end < start) {
+  //   throw new Error('End is less than start, while series is increasing.');
+  // }
+  // if (!isIncreasing && end > start) {
+  //   throw new Error('End is greater than start, while series is decreasing.');
+  // }
 
-  if (isIncreasing && end < start) {
-    throw new Error('End is less than start, while series is increasing.');
-  }
-  if (!isIncreasing && end > start) {
-    throw new Error('End is greater than start, while series is decreasing.');
-  }
+  // if (end == undefined) end = isIncreasing ? maxCeil : minFloor;
 
-  if (end == undefined) end = isIncreasing ? maxCeil : minFloor;
+  // const isInBounds = v => isIncreasing ? v < end : v > end;
 
-  const isInBounds = v => isIncreasing ? v < end : v > end;
+  // let current = start;
+  // do {
+  //   yield current;
+  // } while (isInBounds(current += step));
 
-  let current = start;
-  do {
-    yield current;
-  } while (isInBounds(current += step));
-
-  if (inclusive) yield end;
-  return;
+  // if (inclusive) yield end;
+  // return;
 }

--- a/lib/range.js
+++ b/lib/range.js
@@ -1,37 +1,41 @@
-import reduce from './reduce';
+
+function validateRangeParams(args) {
+  if (args.some(arg => Number.isNaN(arg))) {
+    throw new Error('Start, end, step arguments cannot be NaN.');
+  }
+}
+
+function isIncreasingWithCheck(start, step, end) {
+  const isIncreasing = (start + step) > start;
+
+  if (isIncreasing && end < start) {
+    throw new Error('End is less than start, while series is increasing.');
+  }
+  if (!isIncreasing && end > start) {
+    throw new Error('End is greater than start, while series is decreasing.');
+  }
+
+  return isIncreasing;
+}
 
 export default function *range(start, end, step = 1, inclusive = true) {
-  const args = [+start, +end, +step];
-  const argIsNaN = reduce(
-    (acc, val) => acc |= Number.isNaN(val), // eslint-disable-line no-param-reassign
-    args,
-    false,
-  );
-  if (argIsNaN) throw new Error('Start, end, step arguments cannot be NaN.');
+  let args, _start, _end, _step;
+  args = [_start, _end, _step] = [+start, +end, +step];
 
-  // const argsAreIntegers = args
-  //   .reduce((acc, val) => (acc &= Number.isInteger(val)), true);
+  validateRangeParams(args);
 
-  // const maxCeil = argsAreIntegers ? Number.MAX_SAFE_INTEGER : Number.MAX_VALUE;
-  // const minFloor = argsAreIntegers ? Number.MIN_SAFE_INTEGER : Number.MIN_VALUE;
-  // const isIncreasing = (start + step) > start;
+  const allArgsInt = args.every(arg => Number.isInteger(arg));
+  const maxCeil = allArgsInt ? Number.MAX_SAFE_INTEGER : Number.MAX_VALUE;
+  const minFloor = allArgsInt ? Number.MIN_SAFE_INTEGER : Number.MIN_VALUE;
+  const isIncreasing = isIncreasingWithCheck(_start, _step, _end);
 
-  // if (isIncreasing && end < start) {
-  //   throw new Error('End is less than start, while series is increasing.');
-  // }
-  // if (!isIncreasing && end > start) {
-  //   throw new Error('End is greater than start, while series is decreasing.');
-  // }
+  if (_end == undefined) _end = isIncreasing ? maxCeil : minFloor;
+  const isInBounds = v => isIncreasing ? v < _end : v > _end;
 
-  // if (end == undefined) end = isIncreasing ? maxCeil : minFloor;
+  let current = _start;
+  do {
+    yield current;
+  } while (isInBounds(current += _step));
 
-  // const isInBounds = v => isIncreasing ? v < end : v > end;
-
-  // let current = start;
-  // do {
-  //   yield current;
-  // } while (isInBounds(current += step));
-
-  // if (inclusive) yield end;
-  // return;
+  if (inclusive) yield _end;
 }

--- a/lib/range.js
+++ b/lib/range.js
@@ -1,0 +1,38 @@
+
+export default function *range(start, end, step = 1, inclusive = true) {
+  const args = [
+    start = +start,
+    end = +end,
+    step = +step,
+  ];
+
+  const argIsNaN = args
+    .reduce((acc, val) => (acc |= Number.isNaN(val)), false);
+  if (argIsNaN) throw new Error('All arguments must be Number type.');
+
+  const argsAreIntegers = args
+    .reduce((acc, val) => (acc &= Number.isInteger(val)), true);
+
+  const maxCeil = argsAreIntegers ? Number.MAX_SAFE_INTEGER : Number.MAX_VALUE;
+  const minFloor = argsAreIntegers ? Number.MIN_SAFE_INTEGER : Number.MIN_VALUE;
+  const isIncreasing = (start + step) > start;
+
+  if (isIncreasing && end < start) {
+    throw new Error('End is less than start, while series is increasing.');
+  }
+  if (!isIncreasing && end > start) {
+    throw new Error('End is greater than start, while series is decreasing.');
+  }
+
+  if (end == undefined) end = isIncreasing ? maxCeil : minFloor;
+
+  const isInBounds = v => isIncreasing ? v < end : v > end;
+
+  let current = start;
+  do {
+    yield current;
+  } while (isInBounds(current += step));
+
+  if (inclusive) yield end;
+  return;
+}

--- a/test/04.range.test.js
+++ b/test/04.range.test.js
@@ -1,0 +1,13 @@
+import test from 'tape';
+import { range } from './../lib/limbda';
+
+test(
+  'range | Test draft:',
+  function testRequiredArguments(t) {
+    t.plan(1);
+    t.deepEquals( // 1
+      [...range(5, 9)],
+      [5, 6, 7, 8, 9], 'Range',
+    );
+  },
+);

--- a/test/04.range.test.js
+++ b/test/04.range.test.js
@@ -2,12 +2,32 @@ import test from 'tape';
 import { range } from './../lib/limbda';
 
 test(
-  'range | Test draft:',
-  function testRequiredArguments(t) {
-    t.plan(1);
-    t.deepEquals( // 1
-      [...range(5, 9)],
-      [5, 6, 7, 8, 9], 'Range',
+  'range | Args start, end & step throw when any of them is NaN:',
+  function throwIfStartEndStepIsNaN(t) {
+    const argIsNaNException = new RegExp('Start, end, step arguments cannot be NaN.');
+    t.plan(3);
+    t.throws( // 1
+      () => [...range('a')],
+      argIsNaNException, '"start" cannot be NaN.'
+    );
+    t.throws( // 2
+      () => [...range(1, 'a')],
+      argIsNaNException, '"end" cannot be NaN.'
+    );
+    t.throws( // 2
+      () => [...range(1, 5, 'a')],
+      argIsNaNException, '"step" cannot be NaN.'
     );
   },
 );
+
+// test(
+//   'range | Test draft:',
+//   function testRequiredArguments(t) {
+//     t.plan(1);
+//     t.deepEquals( // 1
+//       [...range(5, 9)],
+//       [5, 6, 7, 8, 9], 'Range',
+//     );
+//   },
+// );

--- a/test/04.range.test.js
+++ b/test/04.range.test.js
@@ -8,15 +8,41 @@ test(
     t.plan(3);
     t.throws( // 1
       () => [...range('a')],
-      argIsNaNException, '"start" cannot be NaN.'
+      argIsNaNException, '"start" cannot be NaN.',
     );
     t.throws( // 2
       () => [...range(1, 'a')],
-      argIsNaNException, '"end" cannot be NaN.'
+      argIsNaNException, '"end" cannot be NaN.',
+    );
+    t.throws( // 3
+      () => [...range(1, 5, 'a')],
+      argIsNaNException, '"step" cannot be NaN.',
+    );
+  },
+);
+
+test(
+  'range | the from "start" to "end" set must contain series:',
+  function throwIfBoundary(t) {
+    const endLessThanStartException = new RegExp('End is less than start, while series is increasing.');
+    const endGreaterThanStartException = new RegExp('End is greater than start, while series is decreasing.');
+    const seriesIncluded = 'Doesn\'t throw if series is contained by "start-end" interval.';
+    t.plan(4);
+    t.throws( // 1
+      () => [...range(5, 2, +2)],
+      endLessThanStartException, '"end" must be greater than start when series is increasing.',
     );
     t.throws( // 2
-      () => [...range(1, 5, 'a')],
-      argIsNaNException, '"step" cannot be NaN.'
+      () => [...range(1, 10, -2.2)],
+      endGreaterThanStartException, '"end" must be less than start when series is increasing.',
+    );
+    t.doesNotThrow( // 3
+      () => [...range(5, -10, -3)],
+      endLessThanStartException, seriesIncluded,
+    );
+    t.doesNotThrow( // 4
+      () => [...range(1, 10, 3)],
+      endGreaterThanStartException, seriesIncluded,
     );
   },
 );


### PR DESCRIPTION
## What does this PR do?

Makes 2 basic range functions available for `limbda`.

- Fully customizable range generator with `start`, `end`, `step` and `inclusive` range choices.
- A simple range generator that could run indefinite (or at least until reaching IEEE-754 max value). Range always starts with zero and increases monotonically with one.

Range functions are implemented using ES6 generators.

## QA

- [ ] `*range` implementation ready
- [ ] all `*range` test cases implemented
- [ ] `*irange` implementation ready
- [ ] all `*irange` test cases implemented
- [ ] feature exported with `limbda`
- [ ] documentation updated